### PR TITLE
Adding margin to layout

### DIFF
--- a/webapp/src/app/app.component.css
+++ b/webapp/src/app/app.component.css
@@ -5,3 +5,13 @@ lib-revealer {
   height: calc(100% - 48px);
   width: 100%;
 }
+
+.small-vspace {
+  height: 1%;
+}
+
+.white-border {
+  height: 97%;
+  width: 98%;
+  margin: auto;
+}

--- a/webapp/src/app/app.component.html
+++ b/webapp/src/app/app.component.html
@@ -1,21 +1,24 @@
-<mat-grid-list cols="2" rowHeight="50%" gutterSize="20">
-  <mat-grid-tile>
-    <app-query-runner style="width: 100%; height: 100%"></app-query-runner>
-  </mat-grid-tile>
-  <mat-grid-tile
-    style="border: solid"
-    *ngFor="let dataset of datasets; let i = index"
-  >
-    <mat-grid-tile-header>Node {{ i + 1 }}</mat-grid-tile-header>
-    <lib-revealer>
-      <lib-revealer-label>
-        This data is hidden in the node and cannot be seen by the querier.
-        <br />
-        Only updates to the model in encrypted form will ever leave this node.
-        <br />
-        For demonstration purposes, however, you can have a look at the data.
-      </lib-revealer-label>
-      <lib-table-viewer [table]="dataset | async"> </lib-table-viewer>
-    </lib-revealer>
-  </mat-grid-tile>
-</mat-grid-list>
+<div style="height: 1%"></div>
+<div style="height: 97%; width: 98%; margin: auto">
+  <mat-grid-list cols="2" rowHeight="fit" gutterSize="2%" style="height: 100%">
+    <mat-grid-tile>
+      <app-query-runner style="width: 100%; height: 100%"></app-query-runner>
+    </mat-grid-tile>
+    <mat-grid-tile
+      style="border: solid"
+      *ngFor="let dataset of datasets; let i = index"
+    >
+      <mat-grid-tile-header>Node {{ i + 1 }}</mat-grid-tile-header>
+      <lib-revealer>
+        <lib-revealer-label>
+          This data is hidden in the node and cannot be seen by the querier.
+          <br />
+          Only updates to the model in encrypted form will ever leave this node.
+          <br />
+          For demonstration purposes, however, you can have a look at the data.
+        </lib-revealer-label>
+        <lib-table-viewer [table]="dataset | async"> </lib-table-viewer>
+      </lib-revealer>
+    </mat-grid-tile>
+  </mat-grid-list>
+</div>

--- a/webapp/src/app/app.component.html
+++ b/webapp/src/app/app.component.html
@@ -1,5 +1,5 @@
-<div style="height: 1%"></div>
-<div style="height: 97%; width: 98%; margin: auto">
+<div class="small-vspace"></div>
+<div class="white-border">
   <mat-grid-list cols="2" rowHeight="fit" gutterSize="2%" style="height: 100%">
     <mat-grid-tile>
       <app-query-runner style="width: 100%; height: 100%"></app-query-runner>


### PR DESCRIPTION
It seems that mat-grid is quite picky as soon as there is a margin involved.
This is why this double-div clunky setup is used.
Another method would be to use fxLayout directly, something like:

```
<div>
  <div fxLayout="column" fxFlex="100%">
    <div fxLayout="row" fxFlex>
      <p>First tile</p>
    </div>
    <div fxLayout="row" fxFlex>
      <p>Second tile</p>
    </div>
  </div>

  <div fxLayout="column" fxFlex="50%">
    <div fxLayout="row" fxFlex  >
      <p>Third tile</p>
    </div>
    <div fxLayout="row" fxFlex  >
      <p>Fourth tile</p>
    </div>
  </div>
</div>
```