### PR TITLE
Move text from main tab to train tab

### DIFF
--- a/webapp/src/app/app.component.html
+++ b/webapp/src/app/app.component.html
@@ -1,8 +1,8 @@
 <div class="small-vspace"></div>
 <div class="white-border">
-  <mat-grid-list cols="2" rowHeight="fit" gutterSize="2%" style="height: 100%">
+  <mat-grid-list cols="2" rowHeight="fit" gutterSize="2%" class="full-size">
     <mat-grid-tile>
-      <app-query-runner style="width: 100%; height: 100%"></app-query-runner>
+      <app-query-runner class="full-size"></app-query-runner>
     </mat-grid-tile>
     <mat-grid-tile
       style="border: solid"

--- a/webapp/src/app/query-runner/query-runner.component.css
+++ b/webapp/src/app/query-runner/query-runner.component.css
@@ -1,8 +1,6 @@
 .tab-content {
   margin: 5%;
   width: calc(100% - 10%);
-
-  text-align: justify;
 }
 
 mat-form-field {

--- a/webapp/src/app/query-runner/query-runner.component.html
+++ b/webapp/src/app/query-runner/query-runner.component.html
@@ -21,120 +21,122 @@
         trained, and the unlabelled data sample to predict. The result will be
         shown in the last tab.
       </p>
-
-      <ul>
-        <li>
-          <b>Learning rate</b>: how much each iteration is to be taken into
-          account. The greater, the faster it will obtain a solution but the
-          more likely the solution won't be the best one.
-        </li>
-        <li>
-          <b>Elastic rate:</b> how much randomness to add at each local
-          iteration, to try to find a better solution that the previous one.
-        </li>
-        <li>
-          <b>Local iteration count</b>: how many times the local model is
-          trained before doing a network iteration. The greater, the slower it
-          will compute locally but, if the datasets are similar, it would
-          require less network iterations.
-        </li>
-        <li>
-          <b>Local batch size</b>: when computing a local iteration, how many
-          labelled data samples to train upon at the same time. The greater, the
-          more precise the solution will be but the more memory it will take.
-        </li>
-        <li>
-          <b>Network iteration count</b>: how many times is the model on the
-          whole network trained, that is computing an aggregatation of each
-          local model, and used this to feed the next local iterations.
-        </li>
-      </ul>
     </div>
   </mat-tab>
 
   <mat-tab label="Train Model">
-    <form
-      [formGroup]="trainForm"
-      (ngSubmit)="runTrainRequest()"
-      class="tab-content"
-    >
-      <mat-list>
-        <mat-list-item>
-          <mat-form-field>
-            <mat-label>Learning rate</mat-label>
-            <input
-              matInput
-              type="number"
-              min="0.01"
-              max="1"
-              step="0.01"
-              formControlName="learningRate"
-            />
-          </mat-form-field>
-        </mat-list-item>
+    <div fxLayout="row" fxFlex="90%">
+      <div fxLayout="column" fxFlex="30%" style="margin: auto">
+        <form [formGroup]="trainForm" (ngSubmit)="runTrainRequest()">
+          <mat-list>
+            <mat-list-item>
+              <mat-form-field>
+                <mat-label>Learning rate</mat-label>
+                <input
+                  matInput
+                  type="number"
+                  min="0.01"
+                  max="1"
+                  step="0.01"
+                  formControlName="learningRate"
+                />
+              </mat-form-field>
+            </mat-list-item>
 
-        <mat-list-item>
-          <mat-form-field>
-            <mat-label>Elastic rate</mat-label>
-            <input
-              matInput
-              type="number"
-              min="0.01"
-              max="1"
-              step="0.01"
-              formControlName="elasticRate"
-            />
-          </mat-form-field>
-        </mat-list-item>
+            <mat-list-item>
+              <mat-form-field>
+                <mat-label>Elastic rate</mat-label>
+                <input
+                  matInput
+                  type="number"
+                  min="0.01"
+                  max="1"
+                  step="0.01"
+                  formControlName="elasticRate"
+                />
+              </mat-form-field>
+            </mat-list-item>
 
-        <mat-list-item>
-          <mat-form-field>
-            <mat-label>Local iteration count</mat-label>
-            <input
-              matInput
-              type="number"
-              min="1"
-              formControlName="localIterationCount"
-            />
-          </mat-form-field>
-        </mat-list-item>
+            <mat-list-item>
+              <mat-form-field>
+                <mat-label>Local iteration count</mat-label>
+                <input
+                  matInput
+                  type="number"
+                  min="1"
+                  formControlName="localIterationCount"
+                />
+              </mat-form-field>
+            </mat-list-item>
 
-        <mat-list-item>
-          <mat-form-field>
-            <mat-label>Local batch size</mat-label>
-            <input
-              matInput
-              type="number"
-              min="1"
-              formControlName="localBatchSize"
-            />
-          </mat-form-field>
-        </mat-list-item>
+            <mat-list-item>
+              <mat-form-field>
+                <mat-label>Local batch size</mat-label>
+                <input
+                  matInput
+                  type="number"
+                  min="1"
+                  formControlName="localBatchSize"
+                />
+              </mat-form-field>
+            </mat-list-item>
 
-        <mat-list-item>
-          <mat-form-field>
-            <mat-label>Network iteration count (epochs)</mat-label>
-            <input
-              matInput
-              type="number"
-              min="1"
-              formControlName="networkIterationCount"
-            />
-          </mat-form-field>
-        </mat-list-item>
+            <mat-list-item>
+              <mat-form-field>
+                <mat-label>Network iteration count (epochs)</mat-label>
+                <input
+                  matInput
+                  type="number"
+                  min="1"
+                  formControlName="networkIterationCount"
+                />
+              </mat-form-field>
+            </mat-list-item>
 
-        <mat-list-item>
-          <button
-            mat-raised-button
-            color="primary"
-            type="submit"
-            [disabled]="!trainForm.valid"
-          >
-            Train
-          </button>
-        </mat-list-item>
-      </mat-list>
-    </form>
+            <mat-list-item>
+              <button
+                mat-raised-button
+                color="primary"
+                type="submit"
+                [disabled]="!trainForm.valid"
+              >
+                Train
+              </button>
+            </mat-list-item>
+          </mat-list>
+        </form>
+      </div>
+      <div fxLayout="column" fxFlex>
+        <ul>
+          <li>
+            <b>Learning rate</b>: how much each iteration is to be taken into
+            account. The greater, the faster it will obtain a solution but the
+            more likely the solution won't be the best one.
+          </li>
+          <li>
+            <b>Elastic rate:</b> how much randomness to add at each local
+            iteration, to try to find a better solution that the previous one.
+          </li>
+          <li>
+            <b>Local iteration count</b>: how many times the local model is
+            trained before doing a network iteration. The greater, the slower it
+            will compute locally but, if the datasets are similar, it would
+            require less network iterations.
+          </li>
+          <li>
+            <b>Local batch size</b>: when computing a local iteration, how many
+            labelled data samples to train upon at the same time. The greater,
+            the more precise the solution will be but the more memory it will
+            take.
+          </li>
+          <li>
+            <b>Network iteration count</b>: how many times is the model on the
+            whole network trained, that is computing an aggregatation of each
+            local model, and used this to feed the next local iterations.
+          </li>
+        </ul>
+      </div>
+    </div>
   </mat-tab>
 
   <mat-tab label="Predict with a Model">

--- a/webapp/src/app/query-runner/query-runner.component.html
+++ b/webapp/src/app/query-runner/query-runner.component.html
@@ -1,4 +1,7 @@
-<mat-tab-group [(selectedIndex)]="tabIndex">
+<mat-tab-group
+  [(selectedIndex)]="tabIndex"
+  class="mat-tab-fill-height full-size"
+>
   <mat-tab label="Explanations">
     <div class="tab-content">
       <p>
@@ -25,8 +28,8 @@
   </mat-tab>
 
   <mat-tab label="Train Model">
-    <div fxLayout="row" fxFlex="90%">
-      <div fxLayout="column" fxFlex="30%" style="margin: auto">
+    <div fxLayout="row" fxLayoutAlign="center center" class="full-size">
+      <div fxFlex="30%">
         <form [formGroup]="trainForm" (ngSubmit)="runTrainRequest()">
           <mat-list>
             <mat-list-item>
@@ -106,7 +109,7 @@
           </mat-list>
         </form>
       </div>
-      <div fxLayout="column" fxFlex>
+      <div fxFlex="50%">
         <ul>
           <li>
             <b>Learning rate</b>: how much each iteration is to be taken into

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -8,3 +8,13 @@ body {
   margin: 0;
   font-family: Roboto, "Helvetica Neue", sans-serif;
 }
+
+.mat-tab-group.mat-tab-fill-height .mat-tab-body-wrapper {
+  flex: 1 1 100%;
+  height: 100%;
+}
+
+.full-size {
+  height: 100%;
+  width: 100%;
+}


### PR DESCRIPTION
The explanation text should be next to the values to be entered.

Arranged form and explanation. For getting the full height in the tab, used https://github.com/angular/components/issues/708#issuecomment-411532361 - thanks...

Closes #27