### PR TITLE
Add prettier to dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   npm: false # avoid caching empty node_modules
 
 before_script:
-  - npx prettier --check .
+  - npx prettier@2.2.1 --check .
   - ( cd webapp && npm ci && npx eslint --ext ts --max-warnings 0 . )
 script: make
 after_script:


### PR DESCRIPTION
When running prettier on my machine it doesn't take the same version
as the one travis takes, so I cannot make PRs.

This adds the prettier to the dev of webapps, and calls it only
in the webapps directory.